### PR TITLE
remove abandoned typescript job board

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,9 +158,6 @@ A curated list of awesome niche job boards.
 ### Scala
 * [Scala Jobs](https://scalajobs.com)
 
-### TypeScript
-* [TypeScript Jobs](https://typescriptjobs.dev)
-
 ## Remote
 
 * [100% Work From Anywhere jobs](https://www.realworkfromanywhere.com/) - Fully remote jobs to live and work from anywhere


### PR DESCRIPTION
this job board has the latest job posted 2.5 years ago, so it's abandoned and needs to be removed